### PR TITLE
[feat] 티켓 consume 실패 event 로직 추가

### DIFF
--- a/event/consumer.py
+++ b/event/consumer.py
@@ -14,28 +14,24 @@ from event.schema.ticket import TicketShopBuyReq
 async def consume():
     consumer = AIOKafkaConsumer(
         'stage_create_fast', 'stage_create_official', 'stage_confirm',
-        'ticket_shop_buy', 'ticket_buy_point_minus',
+        'ticket_point_minus',
         bootstrap_servers=f'{KAFKA_HOST}:{KAFKA_PORT}'
     )
 
     await consumer.start()
-
     try:
         async for msg in consumer:
-            try:
-                data = json.loads(msg.value.decode('utf-8'))
-                if msg.topic == 'stage_create_fast':
-                    await EventConsumeController.create_stage_fast(CreateStageFast(**data))
-                elif msg.topic == 'stage_create_official':
-                    await EventConsumeController.create_stage_official(CreateStageOfficial(**data))
-                elif msg.topic == 'stage_confirm':
-                    await EventConsumeController.stage_confirm(StageConfirmReq(**data))
-                elif msg.topic == 'ticket_shop_buy':
-                    await EventConsumeController.ticket_buy(TicketShopBuyReq(**data))
-            except Exception as e:
-                logging.error(f'kafka consume format error = ' + str(e))
-
+            data = json.loads(msg.value.decode('utf-8'))
+            logging.info(f'Consume kafka data {data.topic} value: {data}')
+            if msg.topic == 'stage_create_fast':
+                await EventConsumeController.create_stage_fast(CreateStageFast(**data))
+            elif msg.topic == 'stage_create_official':
+                await EventConsumeController.create_stage_official(CreateStageOfficial(**data))
+            elif msg.topic == 'stage_confirm':
+                await EventConsumeController.stage_confirm(StageConfirmReq(**data))
+            elif msg.topic == 'ticket_point_minus':
+                await EventConsumeController.ticket_buy(TicketShopBuyReq(**data))
+    except Exception as e:
+        logging.exception(f'Kafka consume exception {str(e)}')
     finally:
         await consumer.stop()
-
-

--- a/event/consumer.py
+++ b/event/consumer.py
@@ -9,6 +9,7 @@ from event.schema.fast import CreateStageFast
 from event.schema.official import CreateStageOfficial
 from event.schema.stage import StageConfirmReq
 from event.schema.ticket import TicketShopBuyReq
+from event.topic import event_topic
 
 
 async def consume():
@@ -22,15 +23,11 @@ async def consume():
     try:
         async for msg in consumer:
             data = json.loads(msg.value.decode('utf-8'))
-            logging.info(f'Consume kafka data {data.topic} value: {data}')
-            if msg.topic == 'stage_create_fast':
-                await EventConsumeController.create_stage_fast(CreateStageFast(**data))
-            elif msg.topic == 'stage_create_official':
-                await EventConsumeController.create_stage_official(CreateStageOfficial(**data))
-            elif msg.topic == 'stage_confirm':
-                await EventConsumeController.stage_confirm(StageConfirmReq(**data))
-            elif msg.topic == 'ticket_point_minus':
-                await EventConsumeController.ticket_buy(TicketShopBuyReq(**data))
+            logging.info(f'Consume kafka data {msg.topic} value: {data}')
+
+            class_, schema_ = event_topic[msg.topic]
+            await class_(schema_(**data))
+
     except Exception as e:
         logging.exception(f'Kafka consume exception {str(e)}')
     finally:

--- a/event/consumer.py
+++ b/event/consumer.py
@@ -4,11 +4,6 @@ import logging
 from aiokafka import AIOKafkaConsumer
 
 from config import KAFKA_HOST, KAFKA_PORT
-from event.controller import EventConsumeController
-from event.schema.fast import CreateStageFast
-from event.schema.official import CreateStageOfficial
-from event.schema.stage import StageConfirmReq
-from event.schema.ticket import TicketShopBuyReq
 from event.topic import event_topic
 
 

--- a/event/producer.py
+++ b/event/producer.py
@@ -1,6 +1,6 @@
-from aiokafka import AIOKafkaProducer
 import json
 
+from aiokafka import AIOKafkaProducer
 from pydantic import BaseModel
 
 from config import KAFKA_HOST, KAFKA_PORT
@@ -8,8 +8,12 @@ from config import KAFKA_HOST, KAFKA_PORT
 
 class EventProducer:
     @staticmethod
-    async def create_event(topic, msg: BaseModel):
+    async def create_event(topic: str, key: str, value: BaseModel):
         producer = AIOKafkaProducer(bootstrap_servers=f'{KAFKA_HOST}:{KAFKA_PORT}')
         await producer.start()
-        await producer.send_and_wait(topic, json.dumps(msg.dict()).encode('utf-8'))
+        await producer.send_and_wait(
+            key=key,
+            topic=topic,
+            value=json.dumps(value.dict()).encode('utf-8'),
+        )
         await producer.stop()

--- a/event/producer.py
+++ b/event/producer.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from aiokafka import AIOKafkaProducer
 from pydantic import BaseModel
@@ -16,4 +17,5 @@ class EventProducer:
             topic=topic,
             value=json.dumps(value.dict()).encode('utf-8'),
         )
+        logging.info(f'Kafka producer Send {topic} value: {value}')
         await producer.stop()

--- a/event/topic.py
+++ b/event/topic.py
@@ -1,0 +1,13 @@
+from event.controller import EventConsumeController
+from event.schema.fast import CreateStageFast
+from event.schema.official import CreateStageOfficial
+from event.schema.stage import StageConfirmReq
+from event.schema.ticket import TicketShopBuyReq
+
+
+event_topic = {
+    'stage_create_fast': (EventConsumeController.create_stage_fast, CreateStageFast),
+    'stage_create_official': (EventConsumeController.create_stage_official, CreateStageOfficial),
+    'stage_confirm': (EventConsumeController.stage_confirm, StageConfirmReq),
+    'ticket_point_minus': (EventConsumeController.ticket_buy, TicketShopBuyReq)
+}

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import uvicorn
 from fastapi import FastAPI
@@ -13,6 +14,8 @@ from src.ticket.presentation.controller.ticket import router as ticket_router
 from src.minigame.presentation.controller.minigame import router as minigame_router
 
 app = FastAPI()
+
+logging.basicConfig(level=logging.INFO)
 
 
 @app.get('/minigame/health')

--- a/src/cointoss/domain/model/coin_toss_result.py
+++ b/src/cointoss/domain/model/coin_toss_result.py
@@ -1,7 +1,10 @@
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
+
+from minigame.domain.model.minigame import MinigameBetStatus
 
 
 class CoinTossResult(SQLModel, table=True):
@@ -12,5 +15,7 @@ class CoinTossResult(SQLModel, table=True):
     bet_point: int = Field(sa_column=Column(BigInteger()))
     result: bool
     point: int = Field(sa_column=Column(BigInteger()))
+    uuid: UUID = Field(unique=True)
+    status: MinigameBetStatus
 
     __tablename__ = 'tbl_coin_toss_result'

--- a/src/cointoss/domain/model/coin_toss_result.py
+++ b/src/cointoss/domain/model/coin_toss_result.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
 
-from minigame.domain.model.minigame import MinigameBetStatus
+from src.minigame.domain.model.minigame import MinigameBetStatus
 
 
 class CoinTossResult(SQLModel, table=True):

--- a/src/minigame/domain/model/minigame.py
+++ b/src/minigame/domain/model/minigame.py
@@ -10,6 +10,11 @@ class MinigameStatus(Enum):
     PENDING = "PENDING"
 
 
+class MinigameBetStatus(Enum):
+    ROLLBACK = "ROLLBACK"
+    CONFIRMED = "CONFIRMED"
+
+
 class Minigame(SQLModel, table=True):
     minigame_id: int = Field(default=None, primary_key=True)
     stage_id: int = Field(sa_column=Column(BigInteger(), unique=True))

--- a/src/plinko/domain/model/plinko_result.py
+++ b/src/plinko/domain/model/plinko_result.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
 
-from minigame.domain.model.minigame import MinigameBetStatus
+from src.minigame.domain.model.minigame import MinigameBetStatus
 
 
 class PlinkoResult(SQLModel, table=True):

--- a/src/plinko/domain/model/plinko_result.py
+++ b/src/plinko/domain/model/plinko_result.py
@@ -1,7 +1,10 @@
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
+
+from minigame.domain.model.minigame import MinigameBetStatus
 
 
 class PlinkoResult(SQLModel, table=True):
@@ -12,5 +15,7 @@ class PlinkoResult(SQLModel, table=True):
     bet_point: int = Field(sa_column=Column(BigInteger()))
     result: float
     point: int = Field(sa_column=Column(BigInteger()))
+    uuid: UUID = Field(unique=True)
+    status: MinigameBetStatus
 
     __tablename__ = 'tbl_plinko_result'

--- a/src/ticket/domain/model/ticket.py
+++ b/src/ticket/domain/model/ticket.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
@@ -11,5 +12,7 @@ class Ticket(SQLModel, table=True):
     coin_toss_ticket_amount: int = Field(sa_column=Column(BigInteger(), default=0))
     plinko_ticket_amount: int = Field(sa_column=Column(BigInteger(), default=0))
     yavarwee_ticket_amount: int = Field(sa_column=Column(BigInteger(), default=0))
+    uuid: UUID = Field(unique=True)
+    status: Enum
 
     __tablename__ = 'tbl_minigame_ticket'

--- a/src/ticket/domain/model/ticket.py
+++ b/src/ticket/domain/model/ticket.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from sqlalchemy import Column, BigInteger
 from sqlmodel import SQLModel, Field
 
+from src.minigame.domain.model.minigame import MinigameBetStatus
+
 
 class Ticket(SQLModel, table=True):
     ticket_id: Optional[int] = Field(default=None, primary_key=True)
@@ -13,6 +15,6 @@ class Ticket(SQLModel, table=True):
     plinko_ticket_amount: int = Field(sa_column=Column(BigInteger(), default=0))
     yavarwee_ticket_amount: int = Field(sa_column=Column(BigInteger(), default=0))
     uuid: UUID = Field(unique=True)
-    status: Enum
+    status: MinigameBetStatus
 
     __tablename__ = 'tbl_minigame_ticket'

--- a/src/ticket/service/ticket.py
+++ b/src/ticket/service/ticket.py
@@ -1,11 +1,22 @@
+from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from event.schema.ticket import TicketType
-from src.minigame.domain.model.minigame import Minigame
+from event.schema.ticket import TicketType, TicketShopBuyReq
 from src.minigame.domain.repository.minigame import MinigameRepository
 from src.ticket.domain.repository.ticket import TicketRepository
 from src.ticket.presentation.schema.ticket import GetTicketAmountRes
 from src.ticket.domain.model.ticket import Ticket
+from event.producer import EventProducer
+
+class TicketEventFail(BaseModel):
+    id: str
+    stageId: int
+    studentId: int
+    shopMiniGameId: int
+    ticketType: str
+    shopReceiptId: int
+    ticketPrice: int
+    purchaseQuantity: int
 
 
 class TicketService:
@@ -34,23 +45,43 @@ class TicketService:
                 coinToss=ticket.coin_toss_ticket_amount
             )
 
-    async def addition_ticket(self, stage_id, user_id, ticket_amount, game):
-        async with self.session.begin():
-            ticket = await self.ticket_repository.find_ticket_amount_by_stage_id_and_user_id(stage_id=stage_id, user_id=user_id)
-            if ticket is None:
-                minigame = await self.minigame_repository.find_by_stage_id(stage_id)
-                await self.ticket_repository.save(
-                    Ticket(
-                        minigame_id=minigame.minigame_id,
-                        user_id=user_id
-                    )
-                )
-                await self.session.flush()
-                ticket = await self.ticket_repository.find_ticket_amount_by_stage_id_and_user_id(stage_id=stage_id, user_id=user_id)
+    async def addition_ticket(self, data: TicketShopBuyReq):
+        try:
 
-            if game == TicketType.PLINKO:
-                ticket.plinko_ticket_amount += ticket_amount
-            elif game == TicketType.YAVARWEE:
-                ticket.yavarwee_ticket_amount += ticket_amount
-            elif game == TicketType.COINTOSS:
-                ticket.coin_toss_ticket_amount += ticket_amount
+            async with self.session.begin():
+                ticket = await self.ticket_repository.find_ticket_amount_by_stage_id_and_user_id(stage_id=data.stageId, user_id=data.studentId)
+                if ticket is None:
+                    minigame = await self.minigame_repository.find_by_stage_id(data.stageId)
+                    await self.ticket_repository.save(
+                        Ticket(
+                            minigame_id=minigame.minigame_id,
+                            user_id=data.studentId
+                        )
+                    )
+                    await self.session.flush()
+                    ticket = await self.ticket_repository.find_ticket_amount_by_stage_id_and_user_id(stage_id=data.stageId, user_id=data.studentId)
+
+                if data.ticketType == TicketType.PLINKO:
+                    ticket.plinko_ticket_amount += data.purchaseQuantity
+                elif data.ticketType == TicketType.YAVARWEE:
+                    ticket.yavarwee_ticket_amount += data.purchaseQuantity
+                elif data.ticketType == TicketType.COINTOSS:
+                    ticket.coin_toss_ticket_amount += data.purchaseQuantity
+
+        except Exception:
+             await EventProducer.create_event(
+                topic='ticket_addition_failed',
+                key=data.id,
+                value=TicketEventFail(
+                    id=data.id,
+                    stageId=data.stageId,
+                    studentId=data.studentId,
+                    shopMiniGameId=data.shopMiniGameId,
+                    ticketType=data.ticketType,
+                    shopReceiptId=data.shopReceiptId,
+                    ticketPrice=data.ticketPrice,
+                    purchaseQuantity=data.purchaseQuantity
+                ),
+            )
+
+             raise

--- a/src/yavarwee/domain/model/yavarwee_result.py
+++ b/src/yavarwee/domain/model/yavarwee_result.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from sqlalchemy import BigInteger, Column
 from sqlmodel import SQLModel, Field
 
+from minigame.domain.model.minigame import MinigameBetStatus
+
 
 class YavarweeResult(SQLModel, table=True):
     yavarwee_result_id: Optional[int] = Field(default=None, primary_key=True)
@@ -14,5 +16,6 @@ class YavarweeResult(SQLModel, table=True):
     yavarwee_stage: int  # 1~5
     point: int = Field(sa_column=Column(BigInteger()))
     uuid: UUID = Field(unique=True)
+    status: MinigameBetStatus
 
     __tablename__ = 'tbl_yavarwee_result'

--- a/src/yavarwee/domain/model/yavarwee_result.py
+++ b/src/yavarwee/domain/model/yavarwee_result.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import BigInteger, Column
 from sqlmodel import SQLModel, Field
 
-from minigame.domain.model.minigame import MinigameBetStatus
+from src.minigame.domain.model.minigame import MinigameBetStatus
 
 
 class YavarweeResult(SQLModel, table=True):


### PR DESCRIPTION
## 개요
티켓 관련 이벤트 실패시 rollback 로직을 추가했습니다.

## 변경사항
- kafka producer key 추가
- fail 이벤트 발급 추가
- kafka 관련 이벤트 로깅 추가
- model uuid 필드 추가
- consumer 간단한 리펙터링
